### PR TITLE
remove CriOS and FxiOS from Safari detection

### DIFF
--- a/PrivateWindowCheck.js
+++ b/PrivateWindowCheck.js
@@ -1,9 +1,6 @@
 var PrivateWindow = new Promise(function (resolve, reject) {
 	try {
-		var isSafari = navigator.vendor && navigator.vendor.indexOf('Apple') > -1 &&
-			   navigator.userAgent &&
-			   navigator.userAgent.indexOf('CriOS') == -1 &&
-			   navigator.userAgent.indexOf('FxiOS') == -1;
+		var isSafari = navigator.vendor && navigator.vendor.indexOf('Apple') > -1;
 				 
 		if(isSafari){
 			//Safari


### PR DESCRIPTION
All browsers on iOS are based on Safari, so no need to exclude them.